### PR TITLE
Implement Comparable for DatedEvent

### DIFF
--- a/src/main/java/seedu/address/model/person/timetable/DatedEvent.java
+++ b/src/main/java/seedu/address/model/person/timetable/DatedEvent.java
@@ -13,7 +13,7 @@ import java.util.regex.Pattern;
  * Encapsulates an event that is not recurring on a weekly basis.
  * Contains details such as the event name, time block, date, and reminder settings.
  */
-public class DatedEvent {
+public class DatedEvent implements Comparable<DatedEvent> {
     public static final String MESSAGE_CONSTRAINTS =
             "Input should be in the format 'name YYYY-MM-DD HHMM HHMM', \n"
                     + "where:\n"
@@ -90,6 +90,27 @@ public class DatedEvent {
      */
     public static boolean isValidDateTimeString(String test) {
         return test.matches(DATE_TIME_VALIDATION_REGEX);
+    }
+
+    /**
+     * Compares this DatedEvent instance with another instance.
+     * The comparison is primarily based on the event's date. If the dates are the same,
+     * the comparison proceeds to the start time of the associated TimeBlock.
+     *
+     * @param other The other DatedEvent instance to compare against.
+     * @return A negative integer, zero, or a positive integer as this DatedEvent is less than,
+     *         equal to, or greater than the specified DatedEvent.
+     */
+    @Override
+    public int compareTo(DatedEvent other) {
+        // First, compare the dates.
+        int dateComparison = this.date.compareTo(other.date);
+        if (dateComparison != 0) {
+            return dateComparison;
+        }
+
+        // If the dates are the same, compare the time blocks.
+        return this.timeBlock.compareByStartTime(other.timeBlock);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/timetable/HalfHourBlocks.java
+++ b/src/main/java/seedu/address/model/person/timetable/HalfHourBlocks.java
@@ -6,9 +6,11 @@ import java.util.Arrays;
  * Represents the half-hour blocks within a day.
  * Each block is represented as a boolean value indicating if that half-hour block is free.
  */
-public class HalfHourBlocks {
+public class HalfHourBlocks implements Comparable<HalfHourBlocks> {
     private static final int BLOCKS_IN_DAY = 48;
     private final boolean[] blocks = new boolean[BLOCKS_IN_DAY];
+    private final int startHalfHour;
+    private final int endHalfHour;
 
     /**
      * Constructs a new HalfHourBlocks with specified start and end half-hour blocks.
@@ -20,6 +22,8 @@ public class HalfHourBlocks {
         for (int i = startHalfHour; i < endHalfHour; i++) {
             blocks[i] = true;
         }
+        this.startHalfHour = startHalfHour;
+        this.endHalfHour = endHalfHour;
     }
 
     /**
@@ -49,6 +53,11 @@ public class HalfHourBlocks {
             overlap.blocks[i] = this.blocks[i] && other.blocks[i];
         }
         return overlap;
+    }
+
+    @Override
+    public int compareTo(HalfHourBlocks other) {
+        return Integer.compare(this.startHalfHour, other.startHalfHour);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/timetable/TimeBlock.java
+++ b/src/main/java/seedu/address/model/person/timetable/TimeBlock.java
@@ -75,6 +75,16 @@ public class TimeBlock implements Comparable<TimeBlock> {
     }
 
     /**
+     * Compares the start time of this TimeBlock with another TimeBlock's start time.
+     *
+     * @param other The other TimeBlock instance to compare against.
+     * @return A negative integer, zero, or a positive integer as this TimeBlock's start time is less than,
+     *         equal to, or greater than the specified TimeBlock's start time.
+     */
+    public int compareByStartTime(TimeBlock other) {
+        return this.timeBlocks.compareTo(other.timeBlocks);
+    }
+    /**
      * Checks if the current TimeBlock overlaps with another TimeBlock.
      * If there's an overlap, returns a new TimeBlock representing the overlapping period.
      *


### PR DESCRIPTION
- Added `Comparable<DatedEvent>` to `DatedEvent` for ordering based on date and start time.
- Simplified `TimeBlock` comparison to focus on start time.
- Introduced `compareByStartTime` in `TimeBlock` for explicit start time comparisons.
- Updated `HalfHourBlocks` with `compareTo` focusing on `startHalfHour`.
- Enhanced JavaDocs for the new and modified methods to ensure clarity.

This enhancement ensures that DatedEvents can be naturally ordered, and provides a dedicated mechanism for comparing TimeBlocks by their start times.