### PR TITLE
Reformat TimeBlock to abstract class

### DIFF
--- a/src/main/java/seedu/address/model/person/timetable/Cca.java
+++ b/src/main/java/seedu/address/model/person/timetable/Cca.java
@@ -91,9 +91,9 @@ public class Cca extends TimeBlock {
         return test.matches(VALIDATION_REGEX);
     }
 
-    public String getCcaName() {
-        String name = ccaName;
-        return name;
+    @Override
+    public String getName() {
+        return this.ccaName;
     }
 
     @Override
@@ -113,6 +113,7 @@ public class Cca extends TimeBlock {
                 + "}";
     }
 
+    @Override
     public boolean equals(Object other) {
         if (other == this) {
             return true;
@@ -123,8 +124,12 @@ public class Cca extends TimeBlock {
         }
 
         Cca otherCca = (Cca) other;
-        return otherCca.getCcaName().equals(getCcaName())
+        return otherCca.getName().equals(getName())
                 && otherCca.getTimeBlockString().equals(getTimeBlockString());
     }
 
+    @Override
+    public int hashCode() {
+        return toString().hashCode();
+    }
 }

--- a/src/main/java/seedu/address/model/person/timetable/DatedEvent.java
+++ b/src/main/java/seedu/address/model/person/timetable/DatedEvent.java
@@ -150,6 +150,7 @@ public class DatedEvent extends TimeBlock {
                 + " " + super.toString() + " Reminder: " + (hasReminder ? "Yes" : "No");
     }
 
+    @Override
     public String getName() {
         return name;
     }
@@ -158,6 +159,7 @@ public class DatedEvent extends TimeBlock {
         return name + " " + super.getTimeBlockString();
     }
 
+    @Override
     public boolean equals(Object e) {
         if (e == this) {
             return true;
@@ -170,6 +172,11 @@ public class DatedEvent extends TimeBlock {
                     && other.getTimeBlockString().equals(getTimeBlockString())
                     && other.hasReminder() == hasReminder();
         }
+    }
+
+    @Override
+    public int hashCode() {
+        return toString().hashCode();
     }
 
 }

--- a/src/main/java/seedu/address/model/person/timetable/MeetUpEvent.java
+++ b/src/main/java/seedu/address/model/person/timetable/MeetUpEvent.java
@@ -98,6 +98,7 @@ public class MeetUpEvent extends DatedEvent {
                 + " " + super.toString() + " Reminder: " + (super.hasReminder() ? "Yes" : "No");
     }
 
+    @Override
     public boolean equals(Object e) {
         if (e == this) {
             return true;
@@ -109,4 +110,8 @@ public class MeetUpEvent extends DatedEvent {
         }
     }
 
+    @Override
+    public int hashCode() {
+        return toString().hashCode();
+    }
 }

--- a/src/main/java/seedu/address/model/person/timetable/Module.java
+++ b/src/main/java/seedu/address/model/person/timetable/Module.java
@@ -75,11 +75,7 @@ public class Module extends TimeBlock {
         return new Module(newName, super.getTimeBlockString());
     }
 
-    /**
-     * Returns the name of the module.
-     *
-     * @return The name of the module.
-     */
+    @Override
     public String getName() {
         return moduleName;
     }
@@ -121,6 +117,7 @@ public class Module extends TimeBlock {
         return "Module: [" + moduleName + "] " + super.toString();
     }
 
+    @Override
     public boolean equals(Object e) {
         if (e == this) {
             return true;
@@ -131,5 +128,10 @@ public class Module extends TimeBlock {
             return this.moduleName.equals(other.moduleName)
                     && this.getTimeBlockString().equals(other.getTimeBlockString());
         }
+    }
+
+    @Override
+    public int hashCode() {
+        return toString().hashCode();
     }
 }

--- a/src/main/java/seedu/address/model/person/timetable/Schedule.java
+++ b/src/main/java/seedu/address/model/person/timetable/Schedule.java
@@ -1,6 +1,5 @@
 package seedu.address.model.person.timetable;
 
-import java.sql.Date;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -322,7 +321,7 @@ public class Schedule {
             if (module.getName().equals(moduleName)) {
                 modulesList.remove(module);
                 isFound = true;
-                break;  // Exit the loop after the first matching module is removed
+                break; // Exit the loop after the first matching module is removed
             }
         }
 
@@ -357,7 +356,7 @@ public class Schedule {
      */
     public void editCca(String ccaName, String unparsedInput) {
         // Remove all instances of the CCA with the given name
-        ccasList.removeIf(cca -> cca.getCcaName().equals(ccaName));
+        ccasList.removeIf(cca -> cca.getName().equals(ccaName));
 
         // Add the new CCA
         ccasList.add(Cca.newCca(unparsedInput));
@@ -371,10 +370,10 @@ public class Schedule {
     public void deleteCca(String ccaName) {
         boolean isFound = false;
         for (Cca cca : ccasList) {
-            if (cca.getCcaName().equals(ccaName)) {
+            if (cca.getName().equals(ccaName)) {
                 ccasList.remove(cca);
                 isFound = true;
-                break;  // Exit the loop after the first matching CCA is removed
+                break; // Exit the loop after the first matching CCA is removed
             }
         }
 
@@ -420,13 +419,13 @@ public class Schedule {
      *
      * @param eventName Name of the dated event to be removed.
      */
-    public void deleteDatedEvent(String eventName) throws Exception{
-            boolean isFound = false;
+    public void deleteDatedEvent(String eventName) throws Exception {
+        boolean isFound = false;
         for (DatedEvent event : datedEventsList) {
             if (event.getName().equals(eventName)) {
                 datedEventsList.remove(event);
                 isFound = true;
-                break;  // Exit the loop after the first matching event is removed
+                break; // Exit the loop after the first matching event is removed
             }
         }
 
@@ -465,7 +464,7 @@ public class Schedule {
             if (event.getName().equals(meetUpEventName)) {
                 meetUpEventsList.remove(event);
                 isFound = true;
-                break;  // Exit the loop after the first matching event is removed
+                break; // Exit the loop after the first matching event is removed
             }
         }
 
@@ -504,7 +503,8 @@ public class Schedule {
         }
         return sb.toString();
     }
-  
+
+    @Override
     public boolean equals(Object other) {
         if (other == this) {
             return true;
@@ -517,5 +517,10 @@ public class Schedule {
                 && ccasList.equals(otherSchedule.ccasList)
                 && datedEventsList.equals(otherSchedule.datedEventsList)
                 && meetUpEventsList.equals(otherSchedule.meetUpEventsList);
+    }
+
+    @Override
+    public int hashCode() {
+        return toString().hashCode();
     }
 }

--- a/src/main/java/seedu/address/model/person/timetable/TimeBlock.java
+++ b/src/main/java/seedu/address/model/person/timetable/TimeBlock.java
@@ -9,7 +9,7 @@ import java.time.DayOfWeek;
  * Represents a block of time in a day, with a day of the week and start and end times.
  * Guarantees: immutable; is valid as declared in {@link #isValidTimeBlock(String)}}
  */
-public class TimeBlock implements Comparable<TimeBlock> {
+public abstract class TimeBlock implements Comparable<TimeBlock> {
 
     public static final String MESSAGE_CONSTRAINTS = "Timing input should be in the format 'DAY HHMM HHMM', \n"
             + "where 'DAY' is a valid day of the week (e.g., Monday, tuesday, WEDNESDAY), \n"
@@ -84,26 +84,6 @@ public class TimeBlock implements Comparable<TimeBlock> {
     public int compareByStartTime(TimeBlock other) {
         return this.timeBlocks.compareTo(other.timeBlocks);
     }
-    /**
-     * Checks if the current TimeBlock overlaps with another TimeBlock.
-     * If there's an overlap, returns a new TimeBlock representing the overlapping period.
-     *
-     * @param other The other TimeBlock to check against.
-     * @return An Optional containing the overlapping TimeBlock if it exists, or an empty Optional otherwise.
-     */
-    public TimeBlock overlap(TimeBlock other) {
-        if (this.day != other.day) {
-            return null;
-        }
-
-        if (this.timeBlocks.overlaps(other.timeBlocks)) {
-            HalfHourBlocks overlapBlocks = this.timeBlocks.getOverlap(other.timeBlocks);
-            // You can convert overlapBlocks back to a string representation if needed
-            return new TimeBlock(day + " " + overlapBlocks.toString());
-        }
-
-        return null;
-    }
 
     /**
      * Checks if the current {@code TimeBlock} overlaps with the specified {@code TimeBlock}.
@@ -119,6 +99,8 @@ public class TimeBlock implements Comparable<TimeBlock> {
 
         return this.timeBlocks.overlaps(other.timeBlocks);
     }
+
+    public abstract String getName();
 
     public boolean isModule() {
         return false;

--- a/src/main/java/seedu/address/storage/timetable/JsonAdaptedCca.java
+++ b/src/main/java/seedu/address/storage/timetable/JsonAdaptedCca.java
@@ -21,7 +21,7 @@ public class JsonAdaptedCca {
     }
 
     public JsonAdaptedCca(Cca source) {
-        name = source.getCcaName();
+        name = source.getName();
         timeBlockString = source.getTimeBlockString();
     }
     


### PR DESCRIPTION
TimeBlock should not need to be instantiated.

Let's:
- make TimeBlock an abstract class.
- remove methods that create instances of TimeBlock.
- standardize getName() for all subclasses of TimeBlock

Common methods like getName() can now be standardized.