### PR TITLE
Fix bug with add/remove event/schedule commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddScheduleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddScheduleCommand.java
@@ -20,9 +20,9 @@ public class AddScheduleCommand extends Command {
     public static final String COMMAND_WORD = "addschedule";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a schedule to the specified contact.\n"
             + "Parameters: "
-            + "INDEX\n"
-            + "type/EVENT_TYPE\n"
-            + "en/EVENT_NAME\n"
+            + "INDEX "
+            + "type/EVENT_TYPE "
+            + "en/EVENT_NAME"
             + "h/[DAY_OF_WEEK START_TIME [HHMM] END_TIME [HHMM]]\n"
             + "Example: " + COMMAND_WORD
             + " 1"

--- a/src/main/java/seedu/address/logic/commands/RemoveEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemoveEventCommand.java
@@ -25,8 +25,8 @@ public class RemoveEventCommand extends Command {
     public static final String MESSAGE_USAGE =
         "rmevent: Removes an event from the specified contact's calendar.\n"
             + "Parameters: "
-            + "INDEX\n"
-            + "en/EVENT_NAME\n"
+            + "INDEX "
+            + "en/EVENT_NAME \n"
             + "Example: " + COMMAND_WORD
             + " 1"
             + " en/CS2103T Lecture\n"

--- a/src/main/java/seedu/address/logic/commands/RemoveScheduleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemoveScheduleCommand.java
@@ -24,8 +24,8 @@ public class RemoveScheduleCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
         + ": Removes an event from the specified contact's calendar.\n"
         + "Parameters: "
-        + "INDEX (must be a positive integer) "
-        + "type/EVENT_TYPE (must be either 'cca' or 'module') "
+        + "INDEX "
+        + "type/EVENT_TYPE "
         + "en/EVENT_NAME\n"
         + "Example: " + COMMAND_WORD
         + " 1"

--- a/src/main/java/seedu/address/logic/parser/AddEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddEventCommandParser.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENTNAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REMINDER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SCHEDULE;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddEventCommand;
@@ -30,8 +31,26 @@ public class AddEventCommandParser implements Parser<AddEventCommand> {
 
         if (!arePrefixesPresent(argMultimap, PREFIX_EVENTNAME,
             PREFIX_SCHEDULE, PREFIX_REMINDER)) {
-            throw new ParseException(String.format("Command format is invalid! \n"
-                + AddEventCommand.MESSAGE_USAGE));
+                List<Prefix> missingPrefix = getMissingPrefixes(argMultimap, PREFIX_EVENTNAME,
+                    PREFIX_SCHEDULE, PREFIX_REMINDER);
+                String missingPrefixString = "";
+                for (Prefix prefix : missingPrefix) {
+                    missingPrefixString += prefix + " ";
+                }
+                throw new ParseException(String.format("Missing prefix(es) for %s!\n"
+                    + "Message Usage:\n" + AddEventCommand.MESSAGE_USAGE, missingPrefixString));
+        }
+
+        if (!arePrefixesUnique(argMultimap, PREFIX_EVENTNAME,
+            PREFIX_SCHEDULE, PREFIX_REMINDER)) {
+                List<Prefix> duplicatePrefix = getDuplicatePrefixes(argMultimap, PREFIX_EVENTNAME,
+                    PREFIX_SCHEDULE, PREFIX_REMINDER);
+                String duplicatePrefixString = "";
+                for (Prefix prefix : duplicatePrefix) {
+                    duplicatePrefixString += prefix + " ";
+                }
+                throw new ParseException(String.format("You can only have 1 of each prefix!\n"
+                    + "Duplicated prefixes are: " + duplicatePrefixString));
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_EVENTNAME, PREFIX_SCHEDULE,
@@ -68,4 +87,29 @@ public class AddEventCommandParser implements Parser<AddEventCommand> {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
+    /**
+     * Returns the prefixes that is not present in the given {@code ArgumentMultimap}.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    private static List<Prefix> getMissingPrefixes(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).filter(prefix -> argumentMultimap.getValue(prefix).isEmpty())
+            .collect(java.util.stream.Collectors.toList());
+    }
+
+    /**
+     * Returns true if there are duplicate prefixes
+     * @param argumentMultimap
+     * @param prefixes
+     */
+    private static boolean arePrefixesUnique(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getAllValues(prefix).size() == 1);
+    }
+
+    /**
+     * Returns the prefixes that are not unique in the given {@code ArgumentMultimap}.
+     */
+    private static List<Prefix> getDuplicatePrefixes(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).filter(prefix -> argumentMultimap.getAllValues(prefix).size() > 1)
+            .collect(java.util.stream.Collectors.toList());
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/AddScheduleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddScheduleCommandParser.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENTTYPE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REMINDER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SCHEDULE;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddScheduleCommand;
@@ -29,8 +30,26 @@ public class AddScheduleCommandParser implements Parser<AddScheduleCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_EVENTNAME, PREFIX_EVENTTYPE, PREFIX_SCHEDULE);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_EVENTNAME, PREFIX_EVENTTYPE, PREFIX_SCHEDULE)) {
-            throw new ParseException(String.format("Command format is invalid! \n"
-                + AddScheduleCommand.MESSAGE_USAGE));
+            List<Prefix> missingPrefix = getMissingPrefixes(argMultimap, PREFIX_EVENTNAME,
+                PREFIX_EVENTTYPE, PREFIX_SCHEDULE);
+            String missingPrefixString = "";
+            for (Prefix prefix : missingPrefix) {
+                missingPrefixString += prefix + " ";
+            }
+            throw new ParseException(String.format("Missing prefix(es) for %s!\n"
+                + "Message Usage:\n" + AddScheduleCommand.MESSAGE_USAGE, missingPrefixString));
+        }
+
+        if (!arePrefixesUnique(argMultimap, PREFIX_EVENTNAME,
+            PREFIX_EVENTTYPE, PREFIX_SCHEDULE)) {
+            List<Prefix> duplicatePrefix = getDuplicatePrefixes(argMultimap, PREFIX_EVENTNAME,
+                PREFIX_EVENTTYPE, PREFIX_SCHEDULE);
+            String duplicatePrefixString = "";
+            for (Prefix prefix : duplicatePrefix) {
+                duplicatePrefixString += prefix + " ";
+            }
+            throw new ParseException(String.format("You can only have 1 of each prefix!\n"
+                + "Duplicated prefixes are: " + duplicatePrefixString));
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_EVENTNAME, PREFIX_SCHEDULE,
@@ -68,4 +87,29 @@ public class AddScheduleCommandParser implements Parser<AddScheduleCommand> {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
+    /**
+     * Returns the prefixes that is not present in the given {@code ArgumentMultimap}.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    private static List<Prefix> getMissingPrefixes(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).filter(prefix -> argumentMultimap.getValue(prefix).isEmpty())
+            .collect(java.util.stream.Collectors.toList());
+    }
+
+    /**
+     * Returns true if there are duplicate prefixes
+     * @param argumentMultimap
+     * @param prefixes
+     */
+    private static boolean arePrefixesUnique(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getAllValues(prefix).size() == 1);
+    }
+
+    /**
+     * Returns the prefixes that are not unique in the given {@code ArgumentMultimap}.
+     */
+    private static List<Prefix> getDuplicatePrefixes(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).filter(prefix -> argumentMultimap.getAllValues(prefix).size() > 1)
+            .collect(java.util.stream.Collectors.toList());
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/RemoveEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemoveEventCommandParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENTNAME;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.RemoveEventCommand;
@@ -27,13 +28,23 @@ public class RemoveEventCommandParser implements Parser<RemoveEventCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_EVENTNAME);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_EVENTNAME)) {
-            throw new ParseException(String.format("Command format is invalid! \n"
-                + RemoveEventCommand.MESSAGE_USAGE));
+            List<Prefix> missingPrefix = getMissingPrefixes(argMultimap, PREFIX_EVENTNAME);
+            String missingPrefixString = "";
+            for (Prefix prefix : missingPrefix) {
+                missingPrefixString += prefix + " ";
+            }
+            throw new ParseException(String.format("Missing prefix(es) for %s!\n"
+                + "Message Usage:\n" + RemoveEventCommand.MESSAGE_USAGE, missingPrefixString));
         }
 
         if (!arePrefixesUnique(argMultimap, PREFIX_EVENTNAME)) {
+            List<Prefix> duplicatePrefix = getDuplicatePrefixes(argMultimap, PREFIX_EVENTNAME);
+            String duplicatePrefixString = "";
+            for (Prefix prefix : duplicatePrefix) {
+                duplicatePrefixString += prefix + " ";
+            }
             throw new ParseException(String.format("You can only have 1 of each prefix!\n"
-                + RemoveEventCommand.MESSAGE_USAGE));
+                + "Duplicated prefixes are: " + duplicatePrefixString));
         }
 
         try {
@@ -68,5 +79,22 @@ public class RemoveEventCommandParser implements Parser<RemoveEventCommand> {
      */
     private static boolean arePrefixesUnique(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getAllValues(prefix).size() == 1);
+    }
+
+    /**
+     * Returns the prefixes that is not present in the given {@code ArgumentMultimap}.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    private static List<Prefix> getMissingPrefixes(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).filter(prefix -> argumentMultimap.getValue(prefix).isEmpty())
+            .collect(java.util.stream.Collectors.toList());
+    }
+
+    /**
+     * Returns the prefixes that are not unique in the given {@code ArgumentMultimap}.
+     */
+    private static List<Prefix> getDuplicatePrefixes(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).filter(prefix -> argumentMultimap.getAllValues(prefix).size() > 1)
+            .collect(java.util.stream.Collectors.toList());
     }
 }

--- a/src/main/java/seedu/address/logic/parser/RemoveScheduleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemoveScheduleCommandParser.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENTNAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENTTYPE;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.RemoveScheduleCommand;
@@ -28,13 +29,23 @@ public class RemoveScheduleCommandParser implements Parser<RemoveScheduleCommand
                 ArgumentTokenizer.tokenize(args, PREFIX_EVENTNAME, PREFIX_EVENTTYPE);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_EVENTNAME, PREFIX_EVENTTYPE)) {
-            throw new ParseException(String.format("Command format is invalid! \n"
-                + RemoveScheduleCommand.MESSAGE_USAGE));
+            List<Prefix> missingPrefix = getMissingPrefixes(argMultimap, PREFIX_EVENTNAME, PREFIX_EVENTTYPE);
+            String missingPrefixString = "";
+            for (Prefix prefix : missingPrefix) {
+                missingPrefixString += prefix + " ";
+            }
+            throw new ParseException(String.format("Missing prefix(es) for %s!\n"
+                + "Message Usage:\n" + RemoveScheduleCommand.MESSAGE_USAGE, missingPrefixString));
         }
 
         if (!arePrefixesUnique(argMultimap, PREFIX_EVENTNAME, PREFIX_EVENTTYPE)) {
+            List<Prefix> duplicatePrefix = getDuplicatePrefixes(argMultimap, PREFIX_EVENTNAME, PREFIX_EVENTTYPE);
+            String duplicatePrefixString = "";
+            for (Prefix prefix : duplicatePrefix) {
+                duplicatePrefixString += prefix + " ";
+            }
             throw new ParseException(String.format("You can only have 1 of each prefix!\n"
-                + RemoveScheduleCommand.MESSAGE_USAGE));
+                + "Duplicated prefixes are: " + duplicatePrefixString));
         }
 
         try {
@@ -71,5 +82,22 @@ public class RemoveScheduleCommandParser implements Parser<RemoveScheduleCommand
      */
     private static boolean arePrefixesUnique(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getAllValues(prefix).size() == 1);
+    }
+
+    /**
+     * Returns the prefixes that is not present in the given {@code ArgumentMultimap}.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    private static List<Prefix> getMissingPrefixes(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).filter(prefix -> argumentMultimap.getValue(prefix).isEmpty())
+            .collect(java.util.stream.Collectors.toList());
+    }
+
+    /**
+     * Returns the prefixes that are not unique in the given {@code ArgumentMultimap}.
+     */
+    private static List<Prefix> getDuplicatePrefixes(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).filter(prefix -> argumentMultimap.getAllValues(prefix).size() > 1)
+            .collect(java.util.stream.Collectors.toList());
     }
 }


### PR DESCRIPTION
Previously, if there was a duplicate prefix, users would just get error Now, the error will tell users which prefix is duplicated

Similarly, users would just get an error for a missing prefix Now, error will tell users which prefix is missing