### PR TITLE
Bug fix: Exclusive end time for FreeTime

### DIFF
--- a/src/main/java/seedu/address/model/person/timetable/FreeTime.java
+++ b/src/main/java/seedu/address/model/person/timetable/FreeTime.java
@@ -17,7 +17,7 @@ public class FreeTime implements Comparable<FreeTime> {
             + "Day is case-insensitive.";
 
     public static final String VALIDATION_REGEX = "^(?i)(monday|tuesday|wednesday|thursday|friday|saturday|sunday) "
-            + "([01]?\\d|2[0-3])(00|30) ([01]?\\d|2[0-3])(00|30)$"; //format: (case-insensitive) day 2359 2359
+            + "([01]?\\d|2[0-3])(00|30) (([01]?\\d|2[0-3])(00|30)|(2400))$";
 
     public final String freeTimeString;
     private final DayOfWeek day;
@@ -47,6 +47,9 @@ public class FreeTime implements Comparable<FreeTime> {
      * Returns true if a given string is a valid tag name.
      */
     public static boolean isValidFreeTime(String test) {
+        if (!test.matches(VALIDATION_REGEX)) {
+            System.out.println("YOUR INPUT DOESN'T WORK" + test);
+        }
         return test.matches(VALIDATION_REGEX);
     }
 

--- a/src/main/java/seedu/address/model/person/timetable/Module.java
+++ b/src/main/java/seedu/address/model/person/timetable/Module.java
@@ -47,7 +47,8 @@ public class Module extends TimeBlock {
 
         // Check for valid number of parts
         if (parts.length != 4) {
-            throw new IllegalArgumentException("Invalid module input format. Expected: NAME DAY HHMM HHMM");
+            String errorMsg = "Invalid module input format. Expected: NAME DAY HHMM HHMM" + MESSAGE_CONSTRAINTS;
+            throw new IllegalArgumentException(errorMsg);
         }
 
         String name = parts[0];

--- a/src/main/java/seedu/address/model/person/timetable/Schedule.java
+++ b/src/main/java/seedu/address/model/person/timetable/Schedule.java
@@ -107,12 +107,12 @@ public class Schedule {
                     startSlot = slot;
                 } else if (timeSlots[day][slot] && startSlot != -1) {
                     // End of a free time slot
-                    freeTimes.add(createFreeTime(day, startSlot, slot - 1));
+                    freeTimes.add(createFreeTime(day, startSlot, slot));
                     startSlot = -1;
                 }
             }
             if (startSlot != -1) {
-                freeTimes.add(createFreeTime(day, startSlot, 47)); // The entire day is free.
+                freeTimes.add(createFreeTime(day, startSlot, 48)); // The entire day is free.
             }
         }
 

--- a/src/main/java/seedu/address/model/person/timetable/TimeBlock.java
+++ b/src/main/java/seedu/address/model/person/timetable/TimeBlock.java
@@ -17,7 +17,7 @@ public abstract class TimeBlock implements Comparable<TimeBlock> {
             + "Day is case-insensitive. The start time must be before the end time.";
 
     public static final String VALIDATION_REGEX = "^(?i)(monday|tuesday|wednesday|thursday|friday|saturday|sunday) "
-            + "([01]?\\d|2[0-3])(00|30) ([01]?\\d|2[0-3])(00|30)$"; //format: (case-insensitive) day 2359 2359
+            + "([01]?\\d|2[0-3])(00|30) (([01]?\\d|2[0-3])(00|30)|(2400))$"; //format: (case-insensitive) day 2359 2359
 
     private String timeBlockString;
     private final DayOfWeek day;


### PR DESCRIPTION
Schedule sees end time for TimeBlocks as exclusive. If an event is from 1200 - 1230, schedule recognises that the free time before that ends at 1130, not 1200.

Let's:
- make endTime of freetime to be inclusive
- extend the FreeTime and TimeBlock implementation to include accepting 2400 as the endTime.

Now the implementation of FreeTime and TimeBlock allows a range of time intervals starting from 0000 and ending at 2400.

This allows events to end at the latest possible timing, which is actually 12am the next day.

Resolves #231 