### PR TITLE
Fix discrepancies in error message

### DIFF
--- a/src/main/java/seedu/address/model/person/timetable/Schedule.java
+++ b/src/main/java/seedu/address/model/person/timetable/Schedule.java
@@ -365,7 +365,8 @@ public class Schedule {
         }
 
         if (!isFound) {
-            throw new CommandException("CCA " + ccaName + " does not exist!");
+            throw new CommandException("CCA " + ccaName + " does not exist!"
+                    + "Please check that you have entered the correct cca name!\n");
         }
     }
 


### PR DESCRIPTION
Error message thrown for non-existent Cca and Module is different. Updated to be the same.