### PR TITLE
Change error message for add command

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -8,10 +8,12 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AddEventCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Birthday;
@@ -38,12 +40,8 @@ public class AddCommandParser implements Parser<AddCommand> {
                     args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
                         PREFIX_BIRTHDAY, PREFIX_TAG);
 
-        // Check if all prefixes are present
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME , PREFIX_PHONE,
-                PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_BIRTHDAY)
-                || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
-        }
+        checkPresentPrefixes(argMultimap);
+        checkUniquePrefixes(argMultimap);
 
         // Check if all prefixes are unique
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE,
@@ -69,4 +67,71 @@ public class AddCommandParser implements Parser<AddCommand> {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
+    /**
+     * Checks if the required prefixes for adding an event are present in the given argument multimap.
+     * Throws a ParseException if any of the required prefixes are missing.
+     *
+     * @param argumentMultimap The argument multimap to check for the presence of prefixes.
+     * @throws ParseException If any of the required prefixes are missing.
+     */
+    private static void checkPresentPrefixes(ArgumentMultimap argumentMultimap) throws ParseException {
+        if (!arePrefixesPresent(argumentMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                        PREFIX_BIRTHDAY, PREFIX_TAG)) {
+            List<Prefix> missingPrefix = getMissingPrefixes(argumentMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                        PREFIX_BIRTHDAY, PREFIX_TAG);
+            String missingPrefixString = "";
+            for (Prefix prefix : missingPrefix) {
+                missingPrefixString += prefix + " ";
+            }
+            throw new ParseException(String.format("Missing prefix(es) for %s!\n"
+                + "Message Usage:\n" + AddEventCommand.MESSAGE_USAGE, missingPrefixString));
+        }
+    }
+
+    /**
+     * Returns the prefixes that is not present in the given {@code ArgumentMultimap}.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    private static List<Prefix> getMissingPrefixes(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).filter(prefix -> argumentMultimap.getValue(prefix).isEmpty())
+            .collect(java.util.stream.Collectors.toList());
+    }
+
+    /**
+     * Returns true if there are duplicate prefixes
+     * @param argumentMultimap
+     * @param prefixes
+     */
+    private static boolean arePrefixesUnique(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getAllValues(prefix).size() == 1);
+    }
+
+    /**
+     * Checks if the prefixes for event name, schedule and reminder are unique in the given ArgumentMultimap.
+     * Throws a ParseException if there are duplicate prefixes.
+     *
+     * @param argumentMultimap the ArgumentMultimap to check for duplicate prefixes
+     * @throws ParseException if there are duplicate prefixes
+     */
+    private static void checkUniquePrefixes(ArgumentMultimap argumentMultimap) throws ParseException {
+        if (!arePrefixesUnique(argumentMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                        PREFIX_BIRTHDAY, PREFIX_TAG)) {
+            List<Prefix> duplicatePrefix = getDuplicatePrefixes(argumentMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                        PREFIX_BIRTHDAY, PREFIX_TAG);
+            String duplicatePrefixString = "";
+            for (Prefix prefix : duplicatePrefix) {
+                duplicatePrefixString += prefix + " ";
+            }
+            throw new ParseException(String.format("You can only have 1 of each prefix!\n"
+                + "Duplicated prefixes are: " + duplicatePrefixString));
+        }
+    }
+
+    /**
+     * Returns the prefixes that are not unique in the given {@code ArgumentMultimap}.
+     */
+    private static List<Prefix> getDuplicatePrefixes(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).filter(prefix -> argumentMultimap.getAllValues(prefix).size() > 1)
+            .collect(java.util.stream.Collectors.toList());
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
@@ -77,7 +76,8 @@ public class AddCommandParser implements Parser<AddCommand> {
     private static void checkPresentPrefixes(ArgumentMultimap argumentMultimap) throws ParseException {
         if (!arePrefixesPresent(argumentMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
                         PREFIX_BIRTHDAY, PREFIX_TAG)) {
-            List<Prefix> missingPrefix = getMissingPrefixes(argumentMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+            List<Prefix> missingPrefix = getMissingPrefixes(argumentMultimap, PREFIX_NAME,
+                        PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
                         PREFIX_BIRTHDAY, PREFIX_TAG);
             String missingPrefixString = "";
             for (Prefix prefix : missingPrefix) {
@@ -116,7 +116,8 @@ public class AddCommandParser implements Parser<AddCommand> {
     private static void checkUniquePrefixes(ArgumentMultimap argumentMultimap) throws ParseException {
         if (!arePrefixesUnique(argumentMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
                         PREFIX_BIRTHDAY, PREFIX_TAG)) {
-            List<Prefix> duplicatePrefix = getDuplicatePrefixes(argumentMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+            List<Prefix> duplicatePrefix = getDuplicatePrefixes(argumentMultimap, PREFIX_NAME,
+                        PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
                         PREFIX_BIRTHDAY, PREFIX_TAG);
             String duplicatePrefixString = "";
             for (Prefix prefix : duplicatePrefix) {


### PR DESCRIPTION
Previously, if users were missing any prefix for the add command,
the error message would not tell them what te missing prefix was.

I have changed this to make the error message more synonymous with
add/rm event/schedule commands