### PR TITLE
Fix Add Dated Event issue

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -570,6 +570,10 @@ Use case ends.
 
   Use case continues from step 1.
 
+* 1d. Event clashes with other events in the schedule.
+
+    Use case continues from step 1.
+
 **Use case: UC08 - Clear list of friends**
 
 **MSS**

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -237,7 +237,7 @@ Missing prefix(es) for en/ type/ h/ !
 
 * Timeslots added of type `module` will be colored blue, while those of type `CCA` will be colored red.
 * To add an event that lasts until the end of the day (midnight), set the end timing as `2400`. We know it isn't ideal, but bear with us!
-* You will not be allowed to add an event that clashes with any existing events. We are making sure you don't double book!
+* You will not be allowed to add an event that clashes with any current or future events. We are making sure you don't double book!
 
 </div>
 
@@ -304,7 +304,7 @@ Events added outside the current week are not visible! The application is stream
 
 * Timeslots added with this command will be green.
 * To add an event that lasts until the end of the day (midnight), set the end timing as `2400`.
-* You will not be allowed to add an event that clashes with any existing events.
+* You will not be allowed to add an event that clashes with any current or future events. Keep those clashes in mind!
 
 </div>
 
@@ -608,7 +608,7 @@ Missing prefix(es) for en/ type/ h/ !
 
 * Timeslots added of type `module` will be colored blue, while those of type `CCA` will be colored red.
 * To add an event that lasts until the end of the day (midnight), set the end timing as `2400`.
-* You will not be allowed to add an event that clashes with any existing events.
+* You will not be allowed to add an event that clashes with any current or future events.
 
 </div>
 
@@ -685,7 +685,7 @@ Missing prefix(es) for en/ h/ r/ !
 
 * Timeslots added with this command will be green.
 * To add an event that lasts until the end of the day (midnight), set the end timing as `2400`.
-* You will not be allowed to add an event that clashes with any existing events.
+* You will not be allowed to add an event that clashes with any current or future events.
 
 </div>
 

--- a/src/main/java/seedu/address/model/person/timetable/DatedEvent.java
+++ b/src/main/java/seedu/address/model/person/timetable/DatedEvent.java
@@ -165,6 +165,33 @@ public class DatedEvent extends TimeBlock {
         return name + " " + super.getTimeBlockString();
     }
 
+    /**
+     * Checks if this event's date is before the given date.
+     * @param date The date to compare with.
+     * @return true if this event's date is before the given date.
+     */
+    public boolean isBefore(LocalDate date) {
+        return this.date.isBefore(date);
+    }
+
+    /**
+     * Checks if this event overlaps with another event.
+     * This method assumes that two events overlap if they are on the same date.
+     * @param event The event to compare with.
+     * @return true if the events overlap.
+     */
+    public boolean isOverlap(DatedEvent event) {
+        if (!this.date.equals(event.date)) {
+            return false;
+        }
+        int thisStartTime = Integer.parseInt(this.getStartTime());
+        int thisEndTime = Integer.parseInt(this.getEndTime());
+        int eventStartTime = Integer.parseInt(event.getStartTime());
+        int eventEndTime = Integer.parseInt(event.getEndTime());
+
+        return thisStartTime < eventEndTime && thisEndTime > eventStartTime;
+    }
+
     @Override
     public boolean equals(Object e) {
         if (e == this) {

--- a/src/main/java/seedu/address/model/person/timetable/Schedule.java
+++ b/src/main/java/seedu/address/model/person/timetable/Schedule.java
@@ -371,7 +371,7 @@ public class Schedule {
     }
 
     /**
-     * Returns true if the given event overlaps with any event in the schedule
+     * Returns true if the given TimeBlock overlaps with any event in the schedule
      * @param event the event to be checked
      * @return true if the given event overlaps with any event in the schedule
      */
@@ -379,10 +379,46 @@ public class Schedule {
         List<TimeBlock> totalList = new ArrayList<>();
         totalList.addAll(modulesList);
         totalList.addAll(ccasList);
-        totalList.addAll(datedEventsList);
         for (TimeBlock e : totalList) {
             if (event.isOverlap(e)) {
                 return true;
+            }
+        }
+        List<DatedEvent> datedEventsList = getDatedEventsList();
+        LocalDate currentDate = LocalDate.now();
+
+        for (DatedEvent e : datedEventsList) {
+            if (!e.isBefore(currentDate)) {
+                if (event.isOverlap(e)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns true if the given event overlaps with any event in the schedule
+     * @param event the event to be checked
+     * @return true if the given event overlaps with any event in the schedule
+     */
+    public boolean isOverlapping(DatedEvent event) {
+        List<TimeBlock> totalList = new ArrayList<>();
+        totalList.addAll(modulesList);
+        totalList.addAll(ccasList);
+        for (TimeBlock e : totalList) {
+            if (e.isOverlap(event)) {
+                return true;
+            }
+        }
+        List<DatedEvent> datedEventsList = getDatedEventsList();
+        LocalDate currentDate = LocalDate.now();
+
+        for (DatedEvent e : datedEventsList) {
+            if (!e.isBefore(currentDate)) {
+                if (event.isOverlap(e)) {
+                    return true;
+                }
             }
         }
         return false;


### PR DESCRIPTION
When there is a dated event in the past, it stops the
user from adding schedules currently. This should not
make sense.

Fix adding schedules and datedevents to ignore events that
have already passed.